### PR TITLE
Add a graceful_exit option to Worker

### DIFF
--- a/lib/delayed/command.rb
+++ b/lib/delayed/command.rb
@@ -77,6 +77,9 @@ module Delayed
         opt.on('--exit-on-complete', 'Exit when no more jobs are available to run. This will exit if all jobs are scheduled to run in the future.') do
           @options[:exit_on_complete] = true
         end
+        opt.on('--graceful-exit', 'Drain queue then exit when a TERM or INT signal is received.') do
+          @options[:graceful_exit] = true
+        end
         opt.on('--daemon-options a, b, c', Array, 'options to be passed through to daemons gem') do |daemon_options|
           @daemon_options = daemon_options
         end

--- a/lib/delayed/tasks.rb
+++ b/lib/delayed/tasks.rb
@@ -19,7 +19,8 @@ namespace :jobs do
       :min_priority => ENV['MIN_PRIORITY'],
       :max_priority => ENV['MAX_PRIORITY'],
       :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
-      :quiet => ENV['QUIET']
+      :quiet => ENV['QUIET'],
+      :graceful_exit => ENV['GRACEFUL_EXIT'],
     }
 
     @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']

--- a/spec/semaphore.rb
+++ b/spec/semaphore.rb
@@ -1,0 +1,33 @@
+class Semaphore
+  def initialize(count = 0)
+    @count = count
+    @mutex = Mutex.new
+    @condition = ConditionVariable.new
+  end
+
+  def acquire()
+    @mutex.synchronize do
+      until @count > 0
+        @condition.wait(@mutex)
+      end
+      @count -= 1
+    end
+  end
+
+  def release(count = 1)
+    @mutex.synchronize do
+      @count += count
+      @condition.broadcast()
+    end
+  end
+end
+
+SemaphoreJob = Struct.new(:start_semaphore, :end_semaphore, :index) do
+  def perform
+    puts("Starting job #{index}")
+    start_semaphore.acquire()
+    puts("Running job #{index}")
+    end_semaphore.release()
+    puts("Finished job #{index}")
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -180,4 +180,136 @@ describe Delayed::Worker do
       expect(performances).to eq(1)
     end
   end
+
+  describe 'signal handling' do
+    SIGNALS = %w[TERM INT]
+    SIGNAL_HANDLERS = {}
+
+    before(:each) do
+      old_signal_handlers = SIGNALS.each do |signal|
+        SIGNAL_HANDLERS[signal] = Signal.trap signal, 'SYSTEM_DEFAULT'
+      end
+    end
+
+    after(:each) do
+      SIGNAL_HANDLERS.each do |signal, signal_handler|
+        Signal.trap signal, signal_handler
+      end
+    end
+
+    class Semaphore
+      def initialize(count = 0)
+        @count = count
+        @mutex = Mutex.new
+        @condition = ConditionVariable.new
+      end
+
+      def acquire()
+        @mutex.synchronize do
+          until @count > 0
+            @condition.wait(@mutex)
+          end
+          @count -= 1
+        end
+      end
+
+      def release(count = 1)
+        @mutex.synchronize do
+          @count += count
+          @condition.broadcast()
+        end
+      end
+    end
+
+    SemaphoreJob = Struct.new(:semaphore) do
+      def perform
+        semaphore.acquire
+      end
+    end
+
+    context 'graceful_exit = false' do
+      worker_options = {}
+
+      it 'exits after the current job is complete' do
+        semaphore = Semaphore.new
+
+        # Enqueue 10 delayed jobs
+        expect do
+          10.times { Delayed::Job.enqueue SemaphoreJob.new(semaphore) }
+        end.to change { Delayed::Job.count }.by(10)
+        
+        # Start a new worker in a background thread
+        worker = Delayed::Worker.new(worker_options)
+        thread = Thread.new { worker.start }
+
+        # Complete 3 jobs on the queue
+        semaphore.release(3)
+
+        # Send a TERM signal to current process- current job should complete
+        # and then worker should exit
+        Process.kill 'TERM', 0
+
+        # Allow the current job to complete
+        semaphore.release()
+        
+        thread.join
+        expect(Delayed::Job.count).to eq(6)
+      end
+    end
+
+    context 'graceful_exit = true' do
+      worker_options = {graceful_exit: true}
+
+      it 'exits when the queue is drained' do
+        semaphore = Semaphore.new
+
+        # Enqueue 10 delayed jobs
+        expect do
+          10.times { Delayed::Job.enqueue SemaphoreJob.new(semaphore) }
+        end.to change { Delayed::Job.count }.by(10)
+        
+        # Start a new worker in a background thread
+        worker = Delayed::Worker.new(worker_options)
+        thread = Thread.new { worker.start }
+
+        # Complete 3 jobs on the queue
+        semaphore.release(3)
+
+        # Send a TERM signal to current process- all jobs should complete
+        Process.kill 'TERM', 0
+
+        # Allow the next 7 jobs to complete
+        semaphore.release(7)
+        
+        thread.join
+        expect(Delayed::Job.count).to eq(0)
+      end
+
+      it 'exits after the current job if multiple signals are received' do
+        semaphore = Semaphore.new
+
+        # Enqueue 10 delayed jobs
+        expect do
+          10.times { Delayed::Job.enqueue SemaphoreJob.new(semaphore) }
+        end.to change { Delayed::Job.count }.by(10)
+        
+        # Start a new worker in a background thread
+        worker = Delayed::Worker.new(worker_options)
+        thread = Thread.new { worker.start }
+
+        # Complete 3 jobs on the queue
+        semaphore.release(3)
+
+        # Send *two* TERM signals to current process- current job should
+        # complete, then worker should exit
+        2.times { Process.kill 'TERM', 0 }
+
+        # Allow the next job to complete
+        semaphore.release()
+        
+        thread.join
+        expect(Delayed::Job.count).to eq(6)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Worker handles signals by completing the current job and then exiting.
For our purpose, we need the Worker to complete *all* outstanding
jobs before terminating. In order to enable this behaviour, set the
`graceful_exit` option to `true`, or set the `GRACEFUL_EXIT`
environment option if using the Rake task.